### PR TITLE
Removing duplicate statement in php_cs.

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -3,7 +3,6 @@
 $finder = Symfony\Component\Finder\Finder::create()
     ->notPath('bootstrap/*')
     ->notPath('storage/*')
-    ->notPath('storage/*')
     ->notPath('resources/view/mail/*')
     ->in([
         __DIR__ . '/src',


### PR DESCRIPTION
Quick fix for what I believe is an accidental duplicate statement in the `.php_cs` file to exclude the `storage/*` path. 👯‍♂️