### PR TITLE
Updated the shell script to replace the placeholder values such as "skeleton","spatie"

### DIFF
--- a/configure-skeleton.sh
+++ b/configure-skeleton.sh
@@ -39,7 +39,7 @@ echo -e "Author: $author_name ($author_username, $author_email)"
 echo -e "Package: $package_name <$package_description>"
 echo -e "Suggested Class Name: $class_name"
 
-vendor_name=`echo "${author_username^}"`
+vendor_name="$(tr '[:lower:]' '[:upper:]' <<< ${author_username:0:1})${author_username:1}"
 package_name_underscore=`echo "-$package_name-" | tr '-' '_'`
 
 echo

--- a/configure-skeleton.sh
+++ b/configure-skeleton.sh
@@ -60,7 +60,6 @@ for file in $files ; do
     | sed "s/:author_username/$author_username/g" \
     | sed "s/:author_email/$author_email/g" \
     | sed "s/:package_name/$package_name/g" \
-    | sed "s/spatie/$author_name/g" \
     | sed "s/Spatie/$vendor_name/g" \
     | sed "s/_skeleton_/$package_name_underscore/g" \
     | sed "s/skeleton/$package_name/g" \


### PR DESCRIPTION
In the earlier version, we have to manually do the updates of the above-mentioned placeholders and have to rename it too. I've made use of the suggested class name and used it to replace the "Skeleton" word and used the author name as the vendor name ( with first letter capital ). moreover, I 've renamed the files according to the package name, and added composer install and phpunit test to run automatically if the user wants.