### PR TITLE
configure-skeleton changes migration class name but not file name

### DIFF
--- a/configure-skeleton.sh
+++ b/configure-skeleton.sh
@@ -74,6 +74,7 @@ for file in $files ; do
     mv "$temp_file" "$new_file"
 done
 mv "./config/skeleton.php" "./config/${package_name}.php"
+mv "./database/migrations/create_skeleton_table.php.stub" "./database/migrations/create_${package_name_underscore}_table.php.stub"
 
 if confirm "Execute composer install and phpunit test" ; then
     composer install && ./vendor/bin/phpunit

--- a/configure-skeleton.sh
+++ b/configure-skeleton.sh
@@ -74,7 +74,7 @@ for file in $files ; do
     mv "$temp_file" "$new_file"
 done
 mv "./config/skeleton.php" "./config/${package_name}.php"
-mv "./database/migrations/create_skeleton_table.php.stub" "./database/migrations/create_${package_name_underscore}_table.php.stub"
+mv "./database/migrations/create_skeleton_table.php.stub" "./database/migrations/create${package_name_underscore}table.php.stub"
 
 if confirm "Execute composer install and phpunit test" ; then
     composer install && ./vendor/bin/phpunit


### PR DESCRIPTION
This should fix the migration rename problem mentioned in #36