### PR TITLE
Use :package_name placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We highly appreciate you sending us a postcard from your hometown, mentioning wh
 You can install the package via composer:
 
 ```bash
-composer require spatie/package-skeleton-laravel
+composer require spatie/:package_name
 ```
 
 You can publish and run the migrations with:


### PR DESCRIPTION
Updated the `composer require` command in the `README` to use the `:package_name` placeholder.