### PR TITLE
Remove call to `withFactories` method

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,7 +11,7 @@ class TestCase extends Orchestra
     {
         parent::setUp();
 
-        $this->withFactories(__DIR__.'/database/factories');
+        //
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
See #66 

I have kept the `setupUp` method in place for convenience.