### PR TITLE
Laravel 8 model factories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "autoload": {
         "psr-4": {
             "Spatie\\Skeleton\\": "src",
-            "Spatie\\Skeleton\\Database\\Factories\\": "database/factories/"
+            "Spatie\\Skeleton\\Database\\Factories\\": "database/factories"
         }
     },
     "autoload-dev": {

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Skeleton\Factories;
+namespace Spatie\Skeleton\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,7 +11,9 @@ class TestCase extends Orchestra
     {
         parent::setUp();
 
-        //
+        Factory::guessFactoryNamesUsing(
+            fn (string $modelName) => 'Spatie\\Skeleton\\Database\\Factories\\'.class_basename($modelName).'Factory'
+        );
     }
 
     protected function getPackageProviders($app)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Skeleton\Tests;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\Skeleton\SkeletonServiceProvider;
 


### PR DESCRIPTION
I have added the `guessFactoryNamesUsing` in the `setUp` method.

Laravel doesn't know where to find the `Factory` classes and it will assume the default `Database\Factories` namespace.

Note that there is also a `useNamespace` method to set the namespace, but found out this doesn't work here.
Think this could be improved in the framework itself.

Resolves #66 