### PR TITLE
Add `illuminate/contracts`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": "^7.4"
+        "php": "^7.4",
+        "illuminate/contracts": "^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",


### PR DESCRIPTION
I would suggest adding `illuminate/contracts`:`^8.0` as a minimum requirement.