### PR TITLE
change Package to Skeleton

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -35,7 +35,7 @@ class TestCase extends Orchestra
 
         /*
         include_once __DIR__.'/../database/migrations/create_skeleton_table.php.stub';
-        (new \CreatePackageTable())->up();
+        (new \CreateSkeletonTable())->up();
         */
     }
 }


### PR DESCRIPTION
change `CreatePackageTable` to `CreateSkeletonTable`. In this way configure-skeleton.sh can rename the class name correctly.