### PR TITLE
Bugfix: Match Github flow name with Github test badge

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: run-tests
 
 on: [push, pull_request]
 


### PR DESCRIPTION
The name of the test flow used in Github Actions must match the name provided in the badge for tests:

```
// README.md
[![GitHub Tests Action Status](https://img.shields.io/github/workflow/status/:vendor_name/:package_name/run-tests?label=tests)](https://github.com/:vendor_name/:package_name/actions?query=workflow%3ATests+branch%3Amaster)
```
Note that it says `run-tests?...` and this should match the name of the flow specified in `.github/workflows/run-tests.yml` for this image to work.