### PR TITLE
Add testbench.yaml by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,4 @@
 /.php_cs.dist       export-ignore
 /psalm.xml          export-ignore
 /psalm.xml.dist     export-ignore
+/testbench.yaml     export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ coverage
 docs
 phpunit.xml
 psalm.xml
+testbench.yaml
 vendor

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/contracts": "^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0",
+        "orchestra/testbench": "^6.13",
         "phpunit/phpunit": "^9.3",
         "spatie/laravel-ray": "^1.9",
         "vimeo/psalm": "^4.4"

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -1,0 +1,2 @@
+providers:
+  - Spatie\Skeleton\SkeletonServiceProvider


### PR DESCRIPTION
This will auto-register the package service provider when running CLI Commander via Testbench, see <https://packages.tools/testbench/commander.html>

For example, based on Freek live coding https://www.youtube.com/watch?v=3HPTh-EMY2U, you test the `remote` command directly from Testbench (without having a dummy Laravel app).

```
./vendor/bin/testbench remote "whoami"
```