### PR TITLE
Fix test failing when using --prefer-lowest. Using missing methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "spatie/laravel-package-tools": "^1.1",
+        "spatie/laravel-package-tools": "^1.4.3",
         "illuminate/contracts": "^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
The issue is explained here: https://github.com/spatie/laravel-package-tools/issues/20