### PR TITLE
Add short_package_name variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub Code Style Action Status](https://img.shields.io/github/workflow/status/:vendor_name/:package_name/Check%20&%20fix%20styling?label=code%20style)](https://github.com/:vendor_name/:package_name/actions?query=workflow%3A"Check+%26+fix+styling"+branch%3Amaster)
 [![Total Downloads](https://img.shields.io/packagist/dt/:vendor_name/:package_name.svg?style=flat-square)](https://packagist.org/packages/:vendor_name/:package_name)
 
-**Note:** Run `./configure-skeleton` to get started, or manually replace  ```:author_name``` ```:author_username``` ```:author_email``` ```:vendor_name``` ```:package_name``` ```:package_description``` with their correct values in [README.md](README.md), [CHANGELOG.md](CHANGELOG.md), [CONTRIBUTING.md](.github/CONTRIBUTING.md), [LICENSE.md](LICENSE.md) and [composer.json](composer.json) files, then delete this line. You can also run `configure-skeleton.sh` to do this automatically.
+**Note:** Run `./configure-skeleton` to get started, or manually replace  ```:author_name``` ```:author_username``` ```:author_email``` ```:vendor_name``` ```:package_name``` ```:short_package_name``` ```:package_description``` with their correct values in [README.md](README.md), [CHANGELOG.md](CHANGELOG.md), [CONTRIBUTING.md](.github/CONTRIBUTING.md), [LICENSE.md](LICENSE.md) and [composer.json](composer.json) files, then delete this line. You can also run `configure-skeleton.sh` to do this automatically.
 
 This is where your description should go. Limit it to a paragraph or two. Consider adding a small example.
 
@@ -28,13 +28,13 @@ composer require :vendor_name/:package_name
 You can publish and run the migrations with:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\Skeleton\SkeletonServiceProvider" --tag=":package_name-migrations"
+php artisan vendor:publish --provider="Spatie\Skeleton\SkeletonServiceProvider" --tag=":short_package_name-migrations"
 php artisan migrate
 ```
 
 You can publish the config file with:
 ```bash
-php artisan vendor:publish --provider="Spatie\Skeleton\SkeletonServiceProvider" --tag=":package_name-config"
+php artisan vendor:publish --provider="Spatie\Skeleton\SkeletonServiceProvider" --tag=":short_package_name-config"
 ```
 
 This is the contents of the published config file:

--- a/configure-skeleton.sh
+++ b/configure-skeleton.sh
@@ -47,8 +47,11 @@ vendor_name="$(tr '[:lower:]' '[:upper:]' <<< ${vendor_name_unsanitized:0:1})${v
 vendor_name_lowercase=`echo "$vendor_name_unsanitized" | tr '[:upper:]' '[:lower:]'`
 package_name_underscore=`echo "-$package_name-" | tr '-' '_'`
 
+prefix="laravel-"
+short_package_name=${package_name#"$prefix"}
+
 echo
-files=$(grep -E -r -l -i ":author|:vendor|:package|spatie|skeleton" --exclude-dir=vendor ./* ./.github/* | grep -v "$script_name")
+files=$(grep -E -r -l -i ":author|:vendor|:package|:short|spatie|skeleton" --exclude-dir=vendor ./* ./.github/* | grep -v "$script_name")
 
 echo "This script will replace the above values in all relevant files in the project directory."
 if ! confirm "Modify files?" ; then
@@ -66,6 +69,7 @@ for file in $files ; do
     | sed "s/:author_email/$author_email/g" \
     | sed "s/:vendor_name/$vendor_name_lowercase/g" \
     | sed "s/:package_name/$package_name/g" \
+    | sed "s/:short_package_name/$short_package_name/g" \
     | sed "s/Spatie/$vendor_name/g" \
     | sed "s/OriginalVendor/Spatie/g" \
     | sed "s/_skeleton_/$package_name_underscore/g" \
@@ -79,8 +83,6 @@ for file in $files ; do
     mv "$temp_file" "$new_file"
 done
 
-prefix="laravel-"
-short_package_name=${package_name#"$prefix"}
 mv "./config/skeleton.php" "./config/${short_package_name}.php"
 
 if confirm "Execute composer install and phpunit test" ; then


### PR DESCRIPTION
I did this little change to make the configuration compliant with the latest `laravel-package-tools` releases, which use the package's short name in the commands used to publish migration and config files.