### PR TITLE
Add anti slash to the autoload psr-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,13 @@
     },
     "autoload": {
         "psr-4": {
-            "Spatie\\Skeleton\\": "src",
-            "Spatie\\Skeleton\\Database\\Factories\\": "database/factories"
+            "Spatie\\Skeleton\\": "src/",
+            "Spatie\\Skeleton\\Database\\Factories\\": "database/factories/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Spatie\\Skeleton\\Tests\\": "tests"
+            "Spatie\\Skeleton\\Tests\\": "tests/"
         }
     },
     "scripts": {


### PR DESCRIPTION
You should add / at the end of "Spatie\\Skeleton\\": "src/" and "Spatie\\Skeleton\\Tests\\": "tests/"
