### PR TITLE
Use minimum Testbench 6.19 for fluent package:test usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "brianium/paratest": "^6.2",
         "nunomaduro/collision": "^5.3",
-        "orchestra/testbench": "^6.15",
+        "orchestra/testbench": "^6.19",
         "phpunit/phpunit": "^9.3",
         "spatie/laravel-ray": "^1.9",
         "vimeo/psalm": "^4.4"


### PR DESCRIPTION
### Before Testbench 6.19

You need to remember to do the following:

```
./vendor/bin/testbench package:discover
./vendor/bin/testbench package:test --parallel
```
### With Testbench 6.19

No longer need to run `package:discover`, `package:test` will always be available when using `testbench` and no longer accidentally register when using artisan from a Laravel application.

```
./vendor/bin/testbench package:test --parallel
```

