### PR TITLE
Fix "prefer-lowest" test from always failing

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.*
-            testbench: 6.*
+            testbench: ^6.6
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 


### PR DESCRIPTION
Currently the `prefer-lowest` test always fails due to Testbench calling a `getAnnotations()` method that PHPUnit 9.5 no longer provides. See #116 for an example of this failure.

Testbench 6.6.0 fixed this, however `prefer-lowest` currently pulls in 6.0.0.

This PR increases the minimum version tested to `6.6`.