### PR TITLE
Prevent workflow running twice when PRing a branch from the same repo

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,10 @@
 name: run-tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   test:


### PR DESCRIPTION
When creating a PR from a branch within the same repo (i.e. not a fork), the current run-test workflows get triggered twice - for both `push` and `pull_request`:

![image](https://user-images.githubusercontent.com/4977161/113792843-3e36ec80-978a-11eb-93bd-6ce1ac2e1944.png)

(Note this does not happen when others push to their own fork as discovered in my experiment at #118)

This PR makes it so that only pushes and pull requests directly to `master` will trigger a workflow run, which fixes the double-up:

![image](https://user-images.githubusercontent.com/4977161/113793217-198f4480-978b-11eb-9ffd-853cd9ac1f6e.png)

(Side note: I think it would be good to change the default branch to `main` per https://github.com/github/renaming#new-repositories-use-main-as-the-default-branch-name)