### PR TITLE
add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ phpunit.xml
 psalm.xml
 testbench.yaml
 vendor
+node_modules


### PR DESCRIPTION
User may omit adding this when the package has assets and by error commit the node_modules directory.