### PR TITLE
Fix configure errors on macOS

### DIFF
--- a/configure-skeleton.sh
+++ b/configure-skeleton.sh
@@ -110,18 +110,18 @@ grep -E -r -l -i ":author|:vendor|:package|VendorName|skeleton|vendor_name|vendo
     echo "adapting file $file -> $new_file"
         temp_file="$file.temp"
         < "$file" \
-          sed "s/:author_name/$author_name/g" \
-        | sed "s/:author_username/$author_username/g" \
-        | sed "s/author@domain.com/$author_email/g" \
-        | sed "s/:vendor_name/$vendor_name/g" \
-        | sed "s/vendor_slug/$vendor_slug/g" \
-        | sed "s/VendorName/$VendorName/g" \
-        | sed "s/:package_name/$package_name/g" \
-        | sed "s/package_slug/$package_slug/g" \
-        | sed "s/skeleton/$package_slug/g" \
-        | sed "s/Skeleton/$ClassName/g" \
-        | sed "s/:package_description/$package_description/g" \
-        | sed "/^\[\]\(delete\) /d" \
+          sed "s#:author_name#$author_name#g" \
+        | sed "s#:author_username#$author_username#g" \
+        | sed "s#author@domain.com#$author_email#g" \
+        | sed "s#:vendor_name#$vendor_name#g" \
+        | sed "s#vendor_slug#$vendor_slug#g" \
+        | sed "s#VendorName#$VendorName#g" \
+        | sed "s#:package_name#$package_name#g" \
+        | sed "s#package_slug#$package_slug#g" \
+        | sed "s#skeleton#$package_slug#g" \
+        | sed "s#Skeleton#$ClassName#g" \
+        | sed "s#:package_description#$package_description#g" \
+        | sed "#^\[\]\(delete\) #d" \
         > "$temp_file"
         rm -f "$file"
         mv "$temp_file" "$new_file"


### PR DESCRIPTION
Somewhere in one of the files that are being run through `sed` is a forward slash. This causes `sed` to throw errors (`sed: 1: "s/:package_description/ ...": bad flag in substitute command: 'f'`) because it thinks the token is complete before it really is. Changing the delimiters to something else fixes this problem.

I have tested this on macOS 11.4, Bash version: GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin20)