### PR TITLE
feature: allow customising namespace in configure script

### DIFF
--- a/configure-skeleton.sh
+++ b/configure-skeleton.sh
@@ -71,6 +71,7 @@ author_username=$(ask_question "Author username" "$username_guess")
 vendor_name=$(ask_question "Vendor name" "$author_username")
 vendor_slug=$(slugify "$vendor_name")
 VendorName=$(titlecase "$vendor_name" "")
+VendorName=$(ask_question "Vendor namespace" "$VendorName")
 
 current_directory=$(pwd)
 folder_name=$(basename "$current_directory")


### PR DESCRIPTION
This pull request adds a new "Vendor namespace" question to the configuration script, allowing you to customise the vendor namespace.

This is useful for scenarios where the vendor name for the package differs, e.g. I use `ryangjchandler` for the vendor name but `RyanChandler` for the namespace.