### PR TITLE
Placeholder "ClassName" in config/skeleton.php is not replaced

### DIFF
--- a/config/skeleton.php
+++ b/config/skeleton.php
@@ -1,5 +1,5 @@
 <?php
-// config for VendorName/ClassName
+// config for VendorName/Skeleton
 return [
 
 ];


### PR DESCRIPTION
The placeholder `ClassName` in config/skeleton.php is not replaced when running `./configure-skeleton.sh`

This pull request changes the placeholder to use `Skeleton` instead.

**Current behavior**

```
<?php
// config for Vurpa/ClassName
return [

];
```

**With this pull request**

```
<?php
// config for Vurpa/PackageSkeletonLaravel
return [

];
```