### PR TITLE
Fix missing parts in configuration script

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -113,6 +113,7 @@ foreach ($files as $file) {
         ':package_name' => $packageName,
         ':package_slug' => $packageSlug,
         'Skeleton' => $className,
+        'skeleton' => $packageSlug,
         ':package_description' => $description,
     ]);
 
@@ -121,6 +122,8 @@ foreach ($files as $file) {
         str_contains($file, 'src/SkeletonServiceProvider.php') => rename($file, './src/' . $className . 'ServiceProvider.php'),
         str_contains($file, 'src/SkeletonFacade.php') => rename($file, './src/' . $className . 'Facade.php'),
         str_contains($file, 'src/Commands/SkeletonCommand.php') => rename($file, './src/Commands/' . $className . 'Command.php'),
+        str_contains($file, 'database/migrations/create_skeleton_table.php.stub') => rename($file, './database/migrations/create_' . $packageSlug . '_table.php.stub'),
+        str_contains($file, 'config/skeleton.php') => rename($file, './config/' . $packageSlug . '.php'),
         default => [],
     };
 }


### PR DESCRIPTION
There are some missing parts on configuration.php file. I think it's related to #146, the PHP configuration script added instead of the bash script does not do some of the things that the bash script does.

The problems that I encounter:
- does not rename migration file
- does not rename config file
- does not change `skeleton` in all files, (it only changes `Skeleton` but code includes both `Skeleton` and `skeleton`)

I think I fixed all of them but I was using this package first time. So I'm not sure whether the missing parts and all use cases are covered. It would be great if you could check it out, thanks!