### PR TITLE
Fix setUp() signature to match with Pest

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,7 +8,7 @@ use VendorName\Skeleton\SkeletonServiceProvider;
 
 class TestCase extends Orchestra
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
If the setUp() signature is public instead of protected an error will be thrown by Pest:

`Access level to Pest\Concerns\Testable::setUp() must be public (as in class VendorName\Skeleton\Tests\TestCase)
`
and tests will not run.   This fixes the issue, bringing it in line with the Orchestra TestBench documentation.