### PR TITLE
hasMiddleware feature added - See also in laravel-package-tools:featu…

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -139,6 +139,7 @@ foreach ($files as $file) {
         str_contains($file, 'src/SkeletonServiceProvider.php') => rename($file, './src/' . $className . 'ServiceProvider.php'),
         str_contains($file, 'src/SkeletonFacade.php') => rename($file, './src/' . $className . 'Facade.php'),
         str_contains($file, 'src/Commands/SkeletonCommand.php') => rename($file, './src/Commands/' . $className . 'Command.php'),
+        str_contains($file, 'src/Http/Middleware/SkeletonMiddleware.php') => rename($file, './src/Http/Middleware/' . $className . 'Middleware.php'),
         str_contains($file, 'database/migrations/create_skeleton_table.php.stub') => rename($file, './database/migrations/create_' . $packageSlugWithoutPrefix . '_table.php.stub'),
         str_contains($file, 'config/skeleton.php') => rename($file, './config/' . $packageSlugWithoutPrefix . '.php'),
         default => [],

--- a/src/Http/Middleware/SkeletonMiddleware.php
+++ b/src/Http/Middleware/SkeletonMiddleware.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace VendorName\Skeleton\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class SkeletonMiddleware
+{
+    public function handle(Request $request, Closure $next)
+    {
+        return $next($request);
+    }
+}


### PR DESCRIPTION
**Attention:** This is the companion PR to the [PR "hasMiddleware feature added"](https://github.com/spatie/laravel-package-tools/pull/41)  in **spatie/laravel-package-tools**

This PR implements the default `SkeletonMiddleware` and the _filename replacements_ in `configure.php`

## Feature "hasMiddleware" ([See PR in laravel-package-tools](https://github.com/spatie/laravel-package-tools/pull/41))

"This PR adds the feature hasMiddleware to the laravel-package-tools. If added, the middleware automatically runs on each request. This feature allows to apply a middleware globally or only assign it to a specific middleware group."

Example: `->hasMiddleware(MyMiddleware::class, 'api')`

For a full documentation please see the laravel-package-tools PR.