### PR TITLE
Add template colons into name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "vendor_slug/package_slug",
+    "name": ":vendor_slug/:package_slug",
     "description": ":package_description",
     "keywords": [
         ":vendor_name",


### PR DESCRIPTION
It looks like the colons were removed from the composer.json file yesterday.