### PR TITLE
fixed renaming 'src/Facades/Skeleton.php' in configure.php

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -138,7 +138,7 @@ foreach ($files as $file) {
     match (true) {
         str_contains($file, 'src/Skeleton.php') => rename($file, './src/' . $className . '.php'),
         str_contains($file, 'src/SkeletonServiceProvider.php') => rename($file, './src/' . $className . 'ServiceProvider.php'),
-        str_contains($file, 'src/SkeletonFacade.php') => rename($file, './src/' . $className . 'Facade.php'),
+        str_contains($file, 'src/Facades/Skeleton.php') => rename($file, './src/Facades/' . $className . '.php'),
         str_contains($file, 'src/Commands/SkeletonCommand.php') => rename($file, './src/Commands/' . $className . 'Command.php'),
         str_contains($file, 'database/migrations/create_skeleton_table.php.stub') => rename($file, './database/migrations/create_' . $packageSlugWithoutPrefix . '_table.php.stub'),
         str_contains($file, 'config/skeleton.php') => rename($file, './config/' . $packageSlugWithoutPrefix . '.php'),


### PR DESCRIPTION
It looks like that the folders structures had been updated but the `configure.php` still trying to rename the old facade class.

It was on `src/SkeletonFacade.php` and the current structure is `src/Facades/Skeleton.php`