### PR TITLE
Fix the 'replaceForWindows' function

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -70,26 +70,26 @@ function remove_prefix(string $prefix, string $content): string {
 
 function remove_composer_deps(array $names) {
     $data = json_decode(file_get_contents(__DIR__.'/composer.json'), true);
-    
+
     foreach($data['require-dev'] as $name => $version) {
         if (in_array($name, $names, true)) {
             unset($data['require-dev'][$name]);
         }
     }
-    
+
     file_put_contents(__DIR__.'/composer.json', json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
 }
 
 function remove_composer_script($scriptName) {
     $data = json_decode(file_get_contents(__DIR__.'/composer.json'), true);
-    
+
     foreach($data['scripts'] as $name => $script) {
         if ($scriptName === $name) {
             unset($data['scripts'][$name]);
             break;
         }
     }
-    
+
     file_put_contents(__DIR__.'/composer.json', json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
 }
 
@@ -101,7 +101,7 @@ function safeUnlink(string $filename) {
 
 
 function replaceForWindows(): array {
-    return preg_split('/\\r\\n|\\r|\\n/', run('dir /S /B * | findstr /v /i .github | findstr /v /i vendor | findstr /v /i '.basename(__FILE__).' | findstr /r /i /M /F:/ ":author :vendor :package VendorName skeleton vendor_name vendor_slug author@domain.com"'));
+    return preg_split('/\\r\\n|\\r|\\n/', run('dir /S /B * | findstr /v /i .git\ | findstr /v /i vendor | findstr /v /i '.basename(__FILE__).' | findstr /r /i /M /F:/ ":author :vendor :package VendorName skeleton vendor_name vendor_slug author@domain.com"'));
 }
 
 function replaceForAllOtherOSes(): array {
@@ -203,7 +203,7 @@ if (! $usePhpStan) {
         'phpstan/phpstan-phpunit',
         'nunomaduro/larastan',
     ]);
-    
+
     remove_composer_script('phpstan');
 }
 


### PR DESCRIPTION
The `replaceForWindows` function results a weird behavior. 
With the old function, the files in `.github` like `FUNDING.yml` didn't get affected by the script `configure.php` 
Also, for some reason the script included the file `.git/index`,  which resulted in the following behavior.
``` 
fkous@7rouz MINGW64 /d/testing (main)
$ ./configure.php
Author name (koossaayy):
Author email (tounessna.2010@gmail.com):
Author username (koossaayy):
Vendor name (koossaayy):
Vendor namespace (Koossaayy):
Package name (testing):
Class name (Testing):
Package description (This is my package testing):
Enable PhpStan? (Y/n):
Enable PhpCsFixer? (Y/n):
Use automatic changelog updater workflow? (Y/n):
------
Author     : koossaayy (koossaayy, *********@gmail.com)
Vendor     : koossaayy (koossaayy)
Package    : testing <This is my package testing>
Namespace  : Koossaayy\Testing
Class name : Testing
---
Packages & Utilities
Use PhpCsFixer       : yes
Use Larastan/PhpStan : yes
Use Auto-Changelog   : yes
------
This script will replace the above values in all relevant files in the project directory.
Modify files? (Y/n):
Execute `composer install` and run tests? (y/N):
Let this script delete itself? (Y/n): n

fkous@7rouz MINGW64 /d/testing (main)
$ git add .
Segmentation fault
 ```

Looking into it, it seems the command in the `replaceForWindows` function, doesn't have the same output as the command in `replaceForAllOtherOSes` function. 
When executing the command in `replaceForWindows` function, the following output was the result: 
```
D:\testing>dir /S /B * | findstr /v /i .github | findstr /v /i vendor | findstr /v /i configuration.php | findstr /r /i /M /F:/ ":author :vendor :package VendorName skeleton vendor_name vendor_slug author@domain.com"
D:\testing\CHANGELOG.md
D:\testing\composer.json
D:\testing\configure.php
D:\testing\LICENSE.md
D:\testing\phpunit.xml.dist
D:\testing\README.md
D:\testing\.git\index
D:\testing\config\skeleton.php
D:\testing\database\factories\ModelFactory.php
D:\testing\database\migrations\create_skeleton_table.php.stub
D:\testing\src\Skeleton.php
D:\testing\src\SkeletonServiceProvider.php
D:\testing\src\Commands\SkeletonCommand.php
D:\testing\src\Facades\Skeleton.php
D:\testing\tests\Pest.php
D:\testing\tests\TestCase.php
```

As you can see, the files list contains `.git\index`, which causes the segmentation fault. 
In this PR, I fixed the function, although it's not a hug thing, but with this fix: the out put of the command becomes the following: 

```
D:\testing>dir /S /B * | findstr /v /i .git\ | findstr /v /i vendor | findstr /v /i configuration.php | findstr /r /i /M /F:/ ":author :vendor :package VendorName skeleton vendor_name vendor_slug author@domain.com"
D:\testing\CHANGELOG.md
D:\testing\composer.json
D:\testing\configure.php
D:\testing\LICENSE.md
D:\testing\phpunit.xml.dist
D:\testing\README.md
D:\testing\.github\FUNDING.yml
D:\testing\.github\SECURITY.md
D:\testing\.github\ISSUE_TEMPLATE\config.yml
D:\testing\config\skeleton.php
D:\testing\database\factories\ModelFactory.php
D:\testing\database\migrations\create_skeleton_table.php.stub
D:\testing\src\Skeleton.php
D:\testing\src\SkeletonServiceProvider.php
D:\testing\src\Commands\SkeletonCommand.php
D:\testing\src\Facades\Skeleton.php
D:\testing\tests\Pest.php
D:\testing\tests\TestCase.php`
```

Which contain the files as `FUNDING.yml` and `SECURITY.yml`, and doesn't contain `.git\index`
Following this fix,  the script now can modify and update the files correctly, as the following output : 
```
fkous@7rouz MINGW64 /d/testing (main)
$ ./configure.php
Author name (koossaayy):
Author email (tounessna.2010@gmail.com):
Author username (koossaayy):
Vendor name (koossaayy):
Vendor namespace (Koossaayy):
Package name (testing):
Class name (Testing):
Package description (This is my package testing):
Enable PhpStan? (Y/n):
Enable PhpCsFixer? (Y/n):
Use automatic changelog updater workflow? (Y/n):
------
Author     : koossaayy (koossaayy, tounessna.2010@gmail.com)
Vendor     : koossaayy (koossaayy)
Package    : testing <This is my package testing>
Namespace  : Koossaayy\Testing
Class name : Testing
---
Packages & Utilities
Use PhpCsFixer       : yes
Use Larastan/PhpStan : yes
Use Auto-Changelog   : yes
------
This script will replace the above values in all relevant files in the project directory.
Modify files? (Y/n):
Execute composer install and run tests? (y/N): n
Let this script delete itself? (Y/n): n

fkous@7rouz MINGW64 /d/testing (main)
$ git status
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   .github/FUNDING.yml
        modified:   .github/ISSUE_TEMPLATE/config.yml
        modified:   .github/SECURITY.md
        modified:   CHANGELOG.md
        modified:   LICENSE.md
        modified:   README.md
        modified:   composer.json
        modified:   config/skeleton.php
        modified:   configure.php
        modified:   database/factories/ModelFactory.php
        modified:   database/migrations/create_skeleton_table.php.stub
        modified:   phpunit.xml.dist
        modified:   src/Commands/SkeletonCommand.php
        modified:   src/Facades/Skeleton.php
        modified:   src/Skeleton.php
        modified:   src/SkeletonServiceProvider.php
        modified:   tests/Pest.php
        modified:   tests/TestCase.php

no changes added to commit (use "git add" and/or "git commit -a")

fkous@7rouz MINGW64 /d/testing (main)
$ git add .
warning: LF will be replaced by CRLF in configure.php.
The file will have its original line endings in your working directory
```