### PR TITLE
Prevent dashes (-) from appearing in PHP variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ return [
 ## Usage
 
 ```php
-$skeleton = new VendorName\Skeleton();
-echo $skeleton->echoPhrase('Hello, VendorName!');
+$variable = new VendorName\Skeleton();
+echo $variable->echoPhrase('Hello, VendorName!');
 ```
 
 ## Testing

--- a/configure.php
+++ b/configure.php
@@ -145,6 +145,7 @@ $packageSlugWithoutPrefix = remove_prefix('laravel-', $packageSlug);
 
 $className = title_case($packageName);
 $className = ask('Class name', $className);
+$variableName = lcfirst($className);
 $description = ask('Package description', "This is my package {$packageSlug}");
 
 $usePhpStan = confirm('Enable PhpStan?', true);
@@ -185,6 +186,7 @@ foreach ($files as $file) {
         ':package_slug_without_prefix' => $packageSlugWithoutPrefix,
         'Skeleton' => $className,
         'skeleton' => $packageSlug,
+        'variable' => $variableName,
         ':package_description' => $description,
     ]);
 


### PR DESCRIPTION
The generated boilerplate code in the README contains a variable that will be filled with an illegal character (-) if the package contains multiple words (e.g. test-package). This change turns 

```php
$example-package = new VendorName\ExamplePackage();
echo $example-package->echoPhrase('Hello, VendorName!');
```
into

```php
$examplePackage = new VendorName\ExamplePackage();
echo $examplePackage->echoPhrase('Hello, VendorName!');
```