### PR TITLE
Move contents of config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ You can publish the config file with:
 php artisan vendor:publish --tag=":package_slug-config"
 ```
 
-Optionally, you can publish the views using
-
-```bash
-php artisan vendor:publish --tag=":package_slug-views"
-```
-
 This is the contents of the published config file:
 
 ```php
 return [
 ];
+```
+
+Optionally, you can publish the views using
+
+```bash
+php artisan vendor:publish --tag=":package_slug-views"
 ```
 
 ## Usage


### PR DESCRIPTION
Place it directly after publishing config command documentation