### PR TITLE
Composer scripts fix: `coverage` is a flag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     "scripts": {
         "analyse": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/pest",
-        "test-coverage": "vendor/bin/pest coverage"
+        "test-coverage": "vendor/bin/pest --coverage"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
When running the `composer run test-coverage` script prior to this change it would result in an error. This is due to pest/phpunit attempting to run a file called `coverage`. `coverage` is actually a flag as [documented here](https://pestphp.com/docs/coverage).

Error before:
![Screenshot 2022-01-28 at 22 03 52](https://user-images.githubusercontent.com/2316916/151628015-82cf8052-4e0f-4ebe-b292-cfe1a594f1d8.png)

After:
![Screenshot 2022-01-28 at 22 06 06](https://user-images.githubusercontent.com/2316916/151628067-716a405a-dab7-4a3f-9aea-99771fa817ef.png)

