### PR TITLE
fix collision version string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/contracts": "^9.0"
     },
     "require-dev": {
-        "nunomaduro/collision": "^6/0",
+        "nunomaduro/collision": "^6.0",
         "nunomaduro/larastan": "^1.0",
         "orchestra/testbench": "^7.0",
         "pestphp/pest": "^1.21",


### PR DESCRIPTION
I was not able to run composer install after running configure.php script because of the typo in the template.