### PR TITLE
Bump Larastan to next major version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "nunomaduro/collision": "^6.0",
-        "nunomaduro/larastan": "^1.0",
+        "nunomaduro/larastan": "^2.0.1",
         "orchestra/testbench": "^7.0",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1",


### PR DESCRIPTION
Since the package skeleton is updated to require a minimum of laravel 9 already, might as well bump larastan too.