### PR TITLE
Suppress PHP 8.1 trim() deprecation notice.

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -26,7 +26,7 @@ function writeln(string $line): void {
 }
 
 function run(string $command): string {
-    return trim(shell_exec($command));
+    return trim((string) shell_exec($command));
 }
 
 function str_after(string $subject, string $search): string {


### PR DESCRIPTION
This suppresses the following deprecation notice:

```
➜  package-skeleton-laravel git:(main) php ./configure.php
PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in /Users/rick/Code/dc/src/github-forks/package-skeleton-laravel/configure.php on line 29

Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /Users/rick/Code/dc/src/github-forks/package-skeleton-laravel/configure.php on line 29
Author name:
```