### PR TITLE
Update run-tests.yml

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.0]
+        php: [8.1]
         laravel: [9.*]
         stability: [prefer-lowest, prefer-stable]
         include:


### PR DESCRIPTION
Removed php 8.0 for test environment because in composer.json minimum version for php is declared as 8.1