### PR TITLE
Add optional dependabot support in configure script

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -155,6 +155,7 @@ $description = ask('Package description', "This is my package {$packageSlug}");
 
 $usePhpStan = confirm('Enable PhpStan?', true);
 $usePhpCsFixer = confirm('Enable PhpCsFixer?', true);
+$useDependabot = confirm('Enable Dependabot?', true);
 $useUpdateChangelogWorkflow = confirm('Use automatic changelog updater workflow?', true);
 
 writeln('------');
@@ -167,6 +168,7 @@ writeln("---");
 writeln("Packages & Utilities");
 writeln("Use PhpCsFixer       : " . ($usePhpCsFixer ? 'yes' : 'no'));
 writeln("Use Larastan/PhpStan : " . ($usePhpStan ? 'yes' : 'no'));
+writeln("Use Dependabot       : " . ($useDependabot ? 'yes' : 'no'));
 writeln("Use Auto-Changelog   : " . ($useUpdateChangelogWorkflow ? 'yes' : 'no'));
 writeln('------');
 
@@ -226,6 +228,11 @@ if (! $usePhpStan) {
     ]);
 
     remove_composer_script('phpstan');
+}
+
+if (! $useDependabot) {
+    safeUnlink(__DIR__ . '/.github/dependabot.yml');
+    safeUnlink(__DIR__ . '/.github/workflows/dependabot-auto-merge.yml');
 }
 
 if (! $useUpdateChangelogWorkflow) {


### PR DESCRIPTION
This PR adds support for removing dependabot support from the repository when running the `configure.php` script.  If disabled, it removes `.github/dependabot.yml` and `.github/workflow/dependabot-auto-merge.yml`.

The default value when prompted is to leave the feature enabled.

While dependabot should be used in most cases IMO, to add flexibility to this template repository I felt that making it an optional feature made sense.  