### PR TITLE
Make spatie/laravel-ray package optional

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -156,6 +156,7 @@ $description = ask('Package description', "This is my package {$packageSlug}");
 $usePhpStan = confirm('Enable PhpStan?', true);
 $usePhpCsFixer = confirm('Enable PhpCsFixer?', true);
 $useDependabot = confirm('Enable Dependabot?', true);
+$useLaravelRay = confirm('Use Ray for debugging?', true);
 $useUpdateChangelogWorkflow = confirm('Use automatic changelog updater workflow?', true);
 
 writeln('------');
@@ -169,6 +170,7 @@ writeln("Packages & Utilities");
 writeln("Use PhpCsFixer       : " . ($usePhpCsFixer ? 'yes' : 'no'));
 writeln("Use Larastan/PhpStan : " . ($usePhpStan ? 'yes' : 'no'));
 writeln("Use Dependabot       : " . ($useDependabot ? 'yes' : 'no'));
+writeln("Use Ray App          : " . ($useLaravelRay ? 'yes' : 'no'));
 writeln("Use Auto-Changelog   : " . ($useUpdateChangelogWorkflow ? 'yes' : 'no'));
 writeln('------');
 
@@ -233,6 +235,10 @@ if (! $usePhpStan) {
 if (! $useDependabot) {
     safeUnlink(__DIR__ . '/.github/dependabot.yml');
     safeUnlink(__DIR__ . '/.github/workflows/dependabot-auto-merge.yml');
+}
+
+if (! $useLaravelRay) {
+    remove_composer_deps(['spatie/laravel-ray']);
 }
 
 if (! $useUpdateChangelogWorkflow) {


### PR DESCRIPTION
This PR updates the `configure.php` script to make the `spatie/laravel-ray` package optional, and it defaults to enabled.

While many Laravel packages should use Ray in my opinion, not all developers have Ray and/or want to use it for every package.  This update allows for a streamlined experience by allowing developers to easily remove the `spatie/laravel-ray` package if they don't want or need it.

This PR improves the overall developer experience by allowing for additional initial customization of the package via the easy-to-use configuration script.