### PR TITLE
in Facade creation return a container binding key

### DIFF
--- a/src/Facades/Skeleton.php
+++ b/src/Facades/Skeleton.php
@@ -11,6 +11,6 @@ class Skeleton extends Facade
 {
     protected static function getFacadeAccessor()
     {
-        return 'skeleton';
+        return \VendorName\Skeleton\Skeleton::class;
     }
 }


### PR DESCRIPTION
The getFacadeAccessor method must always return a container binding key. In previous releases of Laravel, this method could return an object instance; however, this behavior is no longer supported.