### PR TITLE
Exclude build folder

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,5 @@
+{
+    "exclude": [
+        "build"
+    ]
+}


### PR DESCRIPTION
This PR adds the pint configuration file for excluding the `build` folder that contains `phpstan` generated cache files.