### PR TITLE
Upgrade laravel-pint-action v0.1.0 to v1.0.0

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -13,7 +13,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Fix PHP code style issues
-        uses: aglipanci/laravel-pint-action@0.1.0
+        uses: aglipanci/laravel-pint-action@1.0.0
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
There were no changes in the action. The maintainer decided to create a new tag and release `v1.0.0`. But Dependabot will be notifying about the upgrade and creating a PR