### PR TITLE
path to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 
 ## Contributing
 
-Please see [CONTRIBUTING](https://github.com/:author_username/.github/blob/main/CONTRIBUTING.md) for details.
+Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ## Security Vulnerabilities
 


### PR DESCRIPTION
I guess that the generated link only works on users' profiles, not enterprise profiles.

As you can see here [https://github.com/elaborate-code/.github/blob/main/CONTRIBUTING.md](https://github.com/elaborate-code/.github/blob/main/CONTRIBUTING.md) it gives 404 while file exists normally [https://github.com/elaborate-code/laravel-resource-routes/blob/main/CONTRIBUTING.md](https://github.com/elaborate-code/laravel-resource-routes/blob/main/CONTRIBUTING.md)