### PR TITLE
Show list of installed dependencies

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,5 +43,8 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
+      - name: List Installed Dependencies
+        run: composer show -D
+
       - name: Execute tests
         run: vendor/bin/pest


### PR DESCRIPTION
It makes it easier to debug if the build is configured correctly. 

Composer for Windows for example doesn't work nicely when you use `^9.0` instead of `9.x`