### PR TITLE
Updated configure.php

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -161,6 +161,13 @@ $currentDirectory = getcwd();
 $folderName = basename($currentDirectory);
 
 $packageName = ask('Package name', $folderName);
+while(str_contains(strtolower($packageName), "laravel"))
+{
+    echo("You should not include the word 'Laravel' in your package name. \n");
+    echo("Laravel Framework vendor:publish tags already contains laravel- prefix. \n");
+    echo("So please avoid including Laravel in your package name. \n");
+    $packageName = ask('Package name', $folderName);
+}
 $packageSlug = slugify($packageName);
 $packageSlugWithoutPrefix = remove_prefix('laravel-', $packageSlug);
 


### PR DESCRIPTION
# Using a word "Laravel" for your package name is a terrible idea. This PR will prevent it from happening.

If you create a package and it's name containing a word "laravel", then publishing view files by running `php artisan vendor:publish` will cause you a problem.

For example, imagine you created a package named : Laravel-Viewtester.
Then package-skeleton-laravel will generate something like `LaravelViewtester/src/LaravelViewtesterServiceProvider.php`.

Inside of this generated file will be like this:
```php
class /LaravelViewtesterServiceProvider extends PackageServiceProvider
{
    public function configurePackage(Package $package): void
    {
        /*
         * This class is a Package Service Provider
         *
         * More info: https://github.com/spatie/laravel-package-tools
         */
        $package
            ->name('laravel-viewtester')
            ->hasConfigFile()
            ->hasViews();
    }
}
```

Now your package is ready and you install this package to new Laravel project by `composer` for testing. Everything seems OK, then you run `php artisan vendor:publish`.  Your terminal shows that all those providers and tags. But instead of `Tag: laravel-viewtester-views` you see `Tag: viewtester-views`.

## How come?

Because package-skelton-laravel uses [laravel-package-tools](https://github.com/spatie/laravel-package-tools), it  publishes those view files by using [these lines of code](https://github.com/spatie/laravel-package-tools/blob/11cdf05a5d747778fad2c098e86cd48d20917e37/src/PackageServiceProvider.php#L66-L68).

```php
$this->publishes([
    $this->package->basePath('/../resources/views') => base_path("resources/views/vendor/{$this->package->shortName()}"),
], "{$this->package->shortName()}-views");
```

Now `shortName()` will remove 'laravel-' prefix from Package name.
```php
public function shortName(): string
{
    return Str::after($this->name, 'laravel-');
}
```

Although you could publish your package view files, Laravel is not going to use it. Because Laravel tries to search `resources/views/vendor/laravel-viewtester/*.blade.php` first, but your published views are located in `resources/views/vendor/viewtester/*.blade.php` instead. So Laravel is not going to find them.

## How this PR will prevent it?

When you run `php ./configure.php` and if you use "laravel" in your package name, this PR warns users try not to use "laravel" for your package name.

Hope this will prevent these mistakes happening again.
