### PR TITLE
Remove hyphens in default VendorNamespace, configure.php

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -154,7 +154,7 @@ $authorUsername = ask('Author username', $usernameGuess);
 
 $vendorName = ask('Vendor name', $authorUsername);
 $vendorSlug = slugify($vendorName);
-$vendorNamespace = ucwords($vendorName);
+$vendorNamespace = str_replace('-', '', ucwords($vendorName));
 $vendorNamespace = ask('Vendor namespace', $vendorNamespace);
 
 $currentDirectory = getcwd();


### PR DESCRIPTION
Update configure.php to remove hyphens for the default/suggested vendor namespace. Example say your github username is `my-user` then the suggested PHP vendor namespace becomes: `My-User` which is invalid for PHP. Simple suggestion to remove the hyphen so it suggests a valid PHP namespace path: `MyUser`.

The fix for line 157:  `$vendorNamespace = str_replace('-', '', ucwords($vendorName));`

Thanks for reviewing and this template!