### PR TITLE
allow composer plugins for test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,11 @@
         "format": "vendor/bin/pint"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true,
+            "phpstan/extension-installer": true
+        }
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
I have used this template several times and stumbled upon the following [issue](https://github.com/elaborate-code/laravel-json-localization/actions/runs/3192843837/jobs/5210776100#step:5:254) a couple of times on the testing workflow and every time I fix it by the change I'm proposing here.