### PR TITLE
Only run workflow when php file is changed

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -1,6 +1,9 @@
 name: Fix PHP code style issues
 
-on: [push]
+on:
+  push:
+    paths:
+      - '**.php'
 
 jobs:
   php-code-styling:


### PR DESCRIPTION
This may be just a small improvement, but I think it would be better to only run Laravel Pint CI when the `.php` file is modified (like in the [`phpstan.yml`](https://github.com/spatie/package-skeleton-laravel/blob/main/.github/workflows/phpstan.yml#L6) workflow). At least the GitHub Action's completion time could be a few seconds faster.