### PR TITLE
Use `composer.json` to register providers for test

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,9 +19,11 @@ class TestCase extends Orchestra
 
     protected function getPackageProviders($app)
     {
-        return [
-            SkeletonServiceProvider::class,
-        ];
+        $composerFile = file_get_contents(__DIR__.'/../composer.json');
+        $json = json_decode($composerFile);
+        $providers = $json->extra->laravel->providers;
+
+        return $providers;
     }
 
     public function getEnvironmentSetUp($app)


### PR DESCRIPTION
Hello!

First of all, thanks for a wonderful set of tools. I'm hoping that this might help speed things up for future package developers. But I understand if it's a little *too* clever. :)

The point of this PR is to automate the process of getting tests working in your package when you have more than one service provider. Since these providers are already registered in the `composer.json` file, it seems natural to me that we could use that when setting up the TestBench.

Let me know what you think!