### PR TITLE
FIX run-tests workflow failing on prefer-lowest runs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,6 +19,7 @@ jobs:
         include:
           - laravel: 9.*
             testbench: 7.*
+            carbon: ^2.63
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -40,7 +41,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies


### PR DESCRIPTION
This pull request aims to fix run-tests workflow which is throwing errors when running on PHP 8.2 and installing dependencies at their lowest version.

A similar fix has been made in laravel/framework: https://github.com/laravel/framework/pull/44374/files

The alternative would then be requiring a minor version of the Laravel framework, but it would probably be too restrictive just for the version of the Carbon dependency