### PR TITLE
UPDATE laravel-package-tools dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "spatie/laravel-package-tools": "^1.13.0",
+        "spatie/laravel-package-tools": "^1.14.0",
         "illuminate/contracts": "^9.0"
     },
     "require-dev": {


### PR DESCRIPTION
This small commit aims to update the laravel-package-tools dependency version.

In the previous version tests were failing after installing dependencies with the `prefer-lowest` option, as in version 1.13.0 the `askToRunMigrations` method was missing