### PR TITLE
[Feature] Bug reporting via GH forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,66 @@
+name: Bug Report
+description: Report an Issue or Bug with the Package
+title: "[Bug]: "
+labels: ["bug"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              We're sorry to hear you have a problem. Can you help us solve it by providing the following details.
+    - type: textarea
+      id: what-happened
+      attributes:
+          label: What happened?
+          description: What did you expect to happen?
+          placeholder: I cannot currently do X thing because when I do, it breaks X thing.
+      validations:
+          required: true
+    - type: textarea
+      id: how-to-reproduce
+      attributes:
+          label: How to reproduce the bug
+          description: How did this occur, please add any config values used and provide a set of reliable steps if possible.
+          placeholder: When I do X I see Y.
+      validations:
+          required: true
+    - type: input
+      id: package-version
+      attributes:
+          label: Package Version
+          description: What version of our Package are you running? Please be as specific as possible
+          placeholder: 2.0.0
+      validations:
+          required: true
+    - type: input
+      id: php-version
+      attributes:
+          label: PHP Version
+          description: What version of PHP are you running? Please be as specific as possible
+          placeholder: 8.2.0
+      validations:
+          required: true
+    - type: input
+      id: laravel-version
+      attributes:
+        label: Laravel Version
+        description: What version of Laravel are you running? Please be as specific as possible
+        placeholder: 9.0.0
+      validations:
+        required: true
+    - type: dropdown
+      id: operating-systems
+      attributes:
+        label: Which operating systems does with happen with?
+        description: You may select more than one.
+        multiple: true
+        options:
+        - macOS
+        - Windows
+        - Linux
+    - type: textarea
+      id: notes
+      attributes:
+          label: Notes
+          description: Use this field to provide any other notes that you feel might be relevant to the issue.
+      validations:
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,6 +9,3 @@ contact_links:
   - name: Report a security issue
     url: https://github.com/:vendor_name/:package_name/security/policy
     about: Learn how to notify us for sensitive bugs
-  - name: Report a bug
-    url: https://github.com/:vendor_name/:package_name/issues/new
-    about: Report a reproducible bug


### PR DESCRIPTION
### Uses Github's issue forms feature

Documentation: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms

Announcement: https://github.blog/changelog/2021-06-23-issues-forms-beta-for-public-repositories/

Example of it in use:
[Feature Flags for Laravel new Issue Page](https://github.com/ylsideas/feature-flags/issues/new/choose)
[Feature Flags for Laravel Bug Report Form](https://github.com/ylsideas/feature-flags/issues/new?assignees=peterfox&labels=bug&template=bug.yml&title=%5BBug%5D%3A+)

---

I've been using this technique for a few months, and it's a lot better in guiding users of a package to provide the correct information. The form will ask for info like what happened, how to reproduce the bug, the package version, PHP version, Laravel version and which operating systems were used. There is also an optional notes field for further thoughts from the end user. The form will also automatically apply a bug label when writing out the bug report and prefix the title with `[Bug] `.

The Issue link can be removed from `.github/ISSUE_TEMPLATE/config.yml` because the `.github/ISSUE_TEMPLATE/bug.yml` file will be found and automatically displayed on the new issue page.