### PR TITLE
Update create_skeleton_table.php.stub

### DIFF
--- a/database/migrations/create_skeleton_table.php.stub
+++ b/database/migrations/create_skeleton_table.php.stub
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create('migration_table_name_table', function (Blueprint $table) {
             $table->id();
@@ -15,5 +15,10 @@ return new class extends Migration
 
             $table->timestamps();
         });
+    }
+    
+    public function down(): void
+    {
+        Schema::dropIfExists('migration_table_name_table');
     }
 };


### PR DESCRIPTION
Motivation:
- Keep up with Laravel migration stubs and the Laravel 10 native php return types use

Changes:
- Added down function
- void as the return type for up and down functions

Doubts:
- Also add the comments (Run the migrations, reverse the migrations) ?