### PR TITLE
Update phpunit.xml.dist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd"
     backupGlobals="false"
     bootstrap="vendor/autoload.php"
     colors="true"
@@ -21,9 +21,6 @@
         </testsuite>
     </testsuites>
     <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
         <report>
             <html outputDirectory="build/coverage"/>
             <text outputFile="build/coverage.txt"/>
@@ -33,4 +30,9 @@
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
Currently when having set up your package and running tests the following warning is being displayed:
<img width="694" alt="Screenshot 2023-07-08 at 11 49 52" src="https://github.com/spatie/package-skeleton-laravel/assets/18613261/79295dba-97aa-4246-a7ad-9602aeb20255">

By running `vendor/bin/phpunit --migrate-configuration` the phpunit.xml.dist file is being backed up to .bak file + the new configuration schema is being applied.

This PR contains the result of running `vendor/bin/phpunit --migrate-configuration` making the configuration up to date.