### PR TITLE
Fix nunomaduro/collision version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.9",
+        "nunomaduro/collision": "^7.8",
         "nunomaduro/larastan": "^2.0.1",
         "orchestra/testbench": "^8.0",
         "pestphp/pest": "^2.0",


### PR DESCRIPTION
Current required version 7.9 does not exist. Use latest availabele version 7.8 instead.