### PR TITLE
Removed trailing comma

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         ],
         "start": [
             "@composer run build",
-            "@php vendor/bin/testbench serve",
+            "@php vendor/bin/testbench serve"
         ],
         "analyse": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/pest",


### PR DESCRIPTION
 In JsonFile.php line 347:
                                                                                
   "./composer.json" does not contain valid JSON                                
   Parse error on line 58:                                                      
   ...nch serve",        ],        "analyse"                                    
   ---------------------^                                                       
   Expected one of: 'STRING', 'NUMBER', 'NULL', 'TRUE', 'FALSE', '{', '[' - It  
    appears you have an extra trailing comma                                    
     