### PR TITLE
Prevent start script timeout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
             "@php vendor/bin/testbench workbench:build --ansi"
         ],
         "start": [
+            "Composer\\Config::disableProcessTimeout",
             "@composer run build",
             "@php vendor/bin/testbench serve"
         ],


### PR DESCRIPTION
Hi

Composer's scripts has a default process timeout of 300, which is obviously not convenient for launching long-running commands.

This PR disables the Composer's process timeout when using the `start` script which starts a PHP server.