### PR TITLE
Enhance Author/Vendor Github username guessing

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -235,7 +235,7 @@ function guessGitHubVendorInfo($authorName, $username): array
     $response = getGitHubApiEndpoint("orgs/{$remoteUrlParts[1]}");
 
     if ($response === null) {
-        return $username;
+        return [$authorName, $username];
     }
 
     return [$response->name ?? $authorName, $response->login ?? $username];

--- a/configure.php
+++ b/configure.php
@@ -198,7 +198,7 @@ function searchCommitsForGithubUsername(): string
 function guessGithubUsernameUsingCli()
 {
     try {
-        if (preg_match('/ogged in to github\.com as ([a-zA-Z-_]+).+/', shell_exec('gh auth status -h github.com'), $matches) === 1) {
+        if (preg_match('/ogged in to github\.com as ([a-zA-Z-_]+).+/', shell_exec('gh auth status -h github.com 2>&1'), $matches)) {
             return $matches[1];
         }
     } catch (Exception $e) {

--- a/configure.php
+++ b/configure.php
@@ -141,7 +141,7 @@ function replaceForAllOtherOSes(): array
     return explode(PHP_EOL, run('grep -E -r -l -i ":author|:vendor|:package|VendorName|skeleton|migration_table_name|vendor_name|vendor_slug|author@domain.com" --exclude-dir=vendor ./* ./.github/* | grep -v '.basename(__FILE__)));
 }
 
-function getGithubApiEndpoint(string $endpoint): ?stdClass
+function getGitHubApiEndpoint(string $endpoint): ?stdClass
 {
     try {
         $curl = curl_init("https://api.github.com/{$endpoint}");
@@ -169,7 +169,7 @@ function getGithubApiEndpoint(string $endpoint): ?stdClass
     return null;
 }
 
-function searchCommitsForGithubUsername(): string
+function searchCommitsForGitHubUsername(): string
 {
     $authorName = strtolower(trim(shell_exec('git config user.name')));
 
@@ -195,7 +195,7 @@ function searchCommitsForGithubUsername(): string
     return explode('@', $firstCommitter['email'])[0] ?? '';
 }
 
-function guessGithubUsernameUsingCli()
+function guessGitHubUsernameUsingCli()
 {
     try {
         if (preg_match('/ogged in to github\.com as ([a-zA-Z-_]+).+/', shell_exec('gh auth status -h github.com 2>&1'), $matches)) {
@@ -208,14 +208,14 @@ function guessGithubUsernameUsingCli()
     return '';
 }
 
-function guessGithubUsername(): string
+function guessGitHubUsername(): string
 {
-    $username = searchCommitsForGithubUsername();
+    $username = searchCommitsForGitHubUsername();
     if (! empty($username)) {
         return $username;
     }
 
-    $username = guessGithubUsernameUsingCli();
+    $username = guessGitHubUsernameUsingCli();
     if (! empty($username)) {
         return $username;
     }
@@ -227,12 +227,12 @@ function guessGithubUsername(): string
     return $remoteUrlParts[1] ?? '';
 }
 
-function guessGithubVendorInfo($authorName, $username): array
+function guessGitHubVendorInfo($authorName, $username): array
 {
     $remoteUrl = shell_exec('git config remote.origin.url');
     $remoteUrlParts = explode('/', str_replace(':', '/', trim($remoteUrl)));
 
-    $response = getGithubApiEndpoint("orgs/{$remoteUrlParts[1]}");
+    $response = getGitHubApiEndpoint("orgs/{$remoteUrlParts[1]}");
 
     if ($response === null) {
         return $username;
@@ -246,12 +246,12 @@ $authorName = ask('Author name', $gitName);
 
 $gitEmail = run('git config user.email');
 $authorEmail = ask('Author email', $gitEmail);
-$authorUsername = ask('Author username', guessGithubUsername());
+$authorUsername = ask('Author username', guessGitHubUsername());
 
-$guessGithubVendorInfo = guessGithubVendorInfo($authorName, $authorUsername);
+$guessGitHubVendorInfo = guessGitHubVendorInfo($authorName, $authorUsername);
 
-$vendorName = ask('Vendor name', $guessGithubVendorInfo[0]);
-$vendorUsername = ask('Vendor username', $guessGithubVendorInfo[1] ?? slugify($vendorName));
+$vendorName = ask('Vendor name', $guessGitHubVendorInfo[0]);
+$vendorUsername = ask('Vendor username', $guessGitHubVendorInfo[1] ?? slugify($vendorName));
 $vendorSlug = slugify($vendorUsername);
 
 $vendorNamespace = str_replace('-', '', ucwords($vendorName));

--- a/configure.php
+++ b/configure.php
@@ -141,19 +141,118 @@ function replaceForAllOtherOSes(): array
     return explode(PHP_EOL, run('grep -E -r -l -i ":author|:vendor|:package|VendorName|skeleton|migration_table_name|vendor_name|vendor_slug|author@domain.com" --exclude-dir=vendor ./* ./.github/* | grep -v '.basename(__FILE__)));
 }
 
+function getGithubApiEndpoint(string $endpoint): ?stdClass
+{
+    try {
+        $curl = curl_init("https://api.github.com/{$endpoint}");
+        curl_setopt_array($curl, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_HTTPGET => true,
+            CURLOPT_HTTPHEADER => [
+                'User-Agent: spatie-configure-script/1.0'
+            ],
+        ]);
+
+        $response = curl_exec($curl);
+        $statusCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+
+        curl_close($curl);
+
+        if ($statusCode === 200) {
+            return json_decode($response);
+        }
+    } catch (Exception $e) {
+        // ignore
+    }
+
+    return null;
+}
+
+function searchCommitsForGithubUsername(): string
+{
+    $authorName = strtolower(trim(shell_exec("git config user.name")));
+
+    $committersRaw = shell_exec("git log --author='@users.noreply.github.com' --pretty='%an:%ae' --reverse");
+    $committersLines = explode("\n", $committersRaw);
+    $committers = array_filter(array_map(function($line) use ($authorName) {
+        $line = trim($line);
+        [$name, $email] = explode(':', $line) + [null, null];
+
+        return [
+            'name' => $name,
+            'email' => $email,
+            'isMatch' => strtolower($name) === $authorName && !str_contains($name, '[bot]')
+        ];
+    }, $committersLines), fn($item) => $item['isMatch']);
+
+    if (empty($committers)) {
+        return '';
+    }
+
+    $firstCommitter = reset($committers);
+    return explode('@', $firstCommitter['email'])[0] ?? '';
+}
+
+function guessGithubUsernameUsingCli()
+{
+    try {
+        if (preg_match('/ogged in to github\.com as ([a-zA-Z-_]+).+/', shell_exec('gh auth status -h github.com'), $matches) === 1) {
+            return $matches[1];
+        }
+    } catch (Exception $e) {
+        // ignore
+    }
+
+    return '';
+}
+
+function guessGithubUsername(): string
+{
+    $username = searchCommitsForGithubUsername();
+    if (!empty($username)) {
+        return $username;
+    }
+
+    $username = guessGithubUsernameUsingCli();
+    if (!empty($username)) {
+        return $username;
+    }
+
+    // fall back to using the username from the git remote
+    $remoteUrl = shell_exec("git config remote.origin.url");
+    $remoteUrlParts = explode('/', str_replace(':', '/', trim($remoteUrl)));
+
+    return $remoteUrlParts[1] ?? '';
+}
+
+function guessGithubVendorInfo($authorName, $username): array
+{
+    $remoteUrl = shell_exec("git config remote.origin.url");
+    $remoteUrlParts = explode('/', str_replace(':', '/', trim($remoteUrl)));
+
+    $response = getGithubApiEndpoint("orgs/{$remoteUrlParts[1]}");
+
+    if ($response === null) {
+        return $username;
+    }
+
+    return [$response->name ?? $authorName, $response->login ?? $username];
+}
+
 $gitName = run('git config user.name');
 $authorName = ask('Author name', $gitName);
 
 $gitEmail = run('git config user.email');
 $authorEmail = ask('Author email', $gitEmail);
+$authorUsername = ask('Author username', guessGithubUsername());
 
-$usernameGuess = explode(':', run('git config remote.origin.url'))[1];
-$usernameGuess = dirname($usernameGuess);
-$usernameGuess = basename($usernameGuess);
-$authorUsername = ask('Author username', $usernameGuess);
+$guessGithubVendorInfo = guessGithubVendorInfo($authorName, $authorUsername);
 
-$vendorName = ask('Vendor name', $authorUsername);
-$vendorSlug = slugify($vendorName);
+$vendorName = ask('Vendor name', $guessGithubVendorInfo[0]);
+$vendorUsername = ask('Vendor username', $guessGithubVendorInfo[1] ?? slugify($vendorName));
+$vendorSlug = slugify($vendorUsername);
+
 $vendorNamespace = str_replace('-', '', ucwords($vendorName));
 $vendorNamespace = ask('Vendor namespace', $vendorNamespace);
 
@@ -183,7 +282,7 @@ writeln("Namespace  : {$vendorNamespace}\\{$className}");
 writeln("Class name : {$className}");
 writeln('---');
 writeln('Packages & Utilities');
-writeln('Use Laravel/Pint       : '.($useLaravelPint ? 'yes' : 'no'));
+writeln('Use Laravel/Pint     : '.($useLaravelPint ? 'yes' : 'no'));
 writeln('Use Larastan/PhpStan : '.($usePhpStan ? 'yes' : 'no'));
 writeln('Use Dependabot       : '.($useDependabot ? 'yes' : 'no'));
 writeln('Use Ray App          : '.($useLaravelRay ? 'yes' : 'no'));

--- a/configure.php
+++ b/configure.php
@@ -150,7 +150,7 @@ function getGithubApiEndpoint(string $endpoint): ?stdClass
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_HTTPGET => true,
             CURLOPT_HTTPHEADER => [
-                'User-Agent: spatie-configure-script/1.0'
+                'User-Agent: spatie-configure-script/1.0',
             ],
         ]);
 
@@ -171,26 +171,27 @@ function getGithubApiEndpoint(string $endpoint): ?stdClass
 
 function searchCommitsForGithubUsername(): string
 {
-    $authorName = strtolower(trim(shell_exec("git config user.name")));
+    $authorName = strtolower(trim(shell_exec('git config user.name')));
 
     $committersRaw = shell_exec("git log --author='@users.noreply.github.com' --pretty='%an:%ae' --reverse");
     $committersLines = explode("\n", $committersRaw);
-    $committers = array_filter(array_map(function($line) use ($authorName) {
+    $committers = array_filter(array_map(function ($line) use ($authorName) {
         $line = trim($line);
         [$name, $email] = explode(':', $line) + [null, null];
 
         return [
             'name' => $name,
             'email' => $email,
-            'isMatch' => strtolower($name) === $authorName && !str_contains($name, '[bot]')
+            'isMatch' => strtolower($name) === $authorName && ! str_contains($name, '[bot]'),
         ];
-    }, $committersLines), fn($item) => $item['isMatch']);
+    }, $committersLines), fn ($item) => $item['isMatch']);
 
     if (empty($committers)) {
         return '';
     }
 
     $firstCommitter = reset($committers);
+
     return explode('@', $firstCommitter['email'])[0] ?? '';
 }
 
@@ -210,17 +211,17 @@ function guessGithubUsernameUsingCli()
 function guessGithubUsername(): string
 {
     $username = searchCommitsForGithubUsername();
-    if (!empty($username)) {
+    if (! empty($username)) {
         return $username;
     }
 
     $username = guessGithubUsernameUsingCli();
-    if (!empty($username)) {
+    if (! empty($username)) {
         return $username;
     }
 
     // fall back to using the username from the git remote
-    $remoteUrl = shell_exec("git config remote.origin.url");
+    $remoteUrl = shell_exec('git config remote.origin.url');
     $remoteUrlParts = explode('/', str_replace(':', '/', trim($remoteUrl)));
 
     return $remoteUrlParts[1] ?? '';
@@ -228,7 +229,7 @@ function guessGithubUsername(): string
 
 function guessGithubVendorInfo($authorName, $username): array
 {
-    $remoteUrl = shell_exec("git config remote.origin.url");
+    $remoteUrl = shell_exec('git config remote.origin.url');
     $remoteUrlParts = explode('/', str_replace(':', '/', trim($remoteUrl)));
 
     $response = getGithubApiEndpoint("orgs/{$remoteUrlParts[1]}");


### PR DESCRIPTION
This PR enhances the configuration script by increasing the accuracy of the current user's GitHub username guess, as well as more accurately guessing the correct name and GitHub username of the vendor.

It adds several attempts at guessing the user's GitHub username, in the following order:
- it searches the commit history for the author's name _(if the project was created using this repository as a template, there will be a commit created by GitHub)_
- it attempts to use the GitHub CLI utility to determine the username
- finally, it falls back to using the username in the git remote url

It also adds guessing of the vendor name and username, by:
- using the username in the git remote url as the vendor name, then calling the GitHub API `/orgs/{username}` to retrieve the correct vendor name and username
- falls back to using the username in the git remote url

These enhancements significantly increase the accuracy of the user and vendor information guesses, providing a more streamlined developer experience during configuration.

This PR also fixes a minor formatting/spacing issue in the output.

ping @freekmurze 