### PR TITLE
Update configure.php to use Larastan Org

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -342,7 +342,7 @@ if (! $usePhpStan) {
         'phpstan/extension-installer',
         'phpstan/phpstan-deprecation-rules',
         'phpstan/phpstan-phpunit',
-        'nunomaduro/larastan',
+        'larastan/larastan',
     ]);
 
     remove_composer_script('phpstan');


### PR DESCRIPTION
Starting with Larastan 2.7.0, the Larastan repository will now be managed under the Larastan organization.  The configure script should adhere to change #312