### PR TITLE
Fixed minimum package version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "larastan/larastan": "^2.0.1",
         "orchestra/testbench": "^8.8",
         "pestphp/pest": "^2.20",
-        "pestphp/pest-plugin-arch": "^2.0",
+        "pestphp/pest-plugin-arch": "^2.5",
         "pestphp/pest-plugin-laravel": "^2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",


### PR DESCRIPTION
The `arch` function was added with version 2.5.0. @freekmurze 

https://github.com/spatie/package-skeleton-laravel/blob/main/tests/ArchTest.php#L3

https://github.com/pestphp/pest-plugin-arch/commit/28519b747e94e25567ece908d580d170a9b1d9d8

```bash
Run vendor/bin/pest --ci

   ERROR  Call to undefined function arch()

Location: /home/runner/work/laravel-stock/laravel-stock/tests/ArchTest.php:3

#0 /home/runner/work/laravel-stock/laravel-stock/vendor/pestphp/pest/overrides/Runner/TestSuiteLoader.php(89): include_once()
#1 /home/runner/work/laravel-stock/laravel-stock/vendor/pestphp/pest/overrides/Runner/TestSuiteLoader.php(92): PHPUnit\Runner\TestSuiteLoader::PHPUnit\Runner\{closure}()
#2 /home/runner/work/laravel-stock/laravel-stock/vendor/phpunit/phpunit/src/Framework/TestSuite.php(244): PHPUnit\Runner\TestSuiteLoader->load()
#3 /home/runner/work/laravel-stock/laravel-stock/vendor/phpunit/phpunit/src/Framework/TestSuite.php(261): PHPUnit\Framework\TestSuite->addTestFile()
#4 /home/runner/work/laravel-stock/laravel-stock/vendor/phpunit/phpunit/src/TextUI/Configuration/Xml/TestSuiteMapper.php(100): PHPUnit\Framework\TestSuite->addTestFiles()
#5 /home/runner/work/laravel-stock/laravel-stock/vendor/phpunit/phpunit/src/TextUI/Configuration/TestSuiteBuilder.php(58): PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper->map()
#6 /home/runner/work/laravel-stock/laravel-stock/vendor/phpunit/phpunit/src/TextUI/Application.php(356): PHPUnit\TextUI\Configuration\TestSuiteBuilder->build()
#7 /home/runner/work/laravel-stock/laravel-stock/vendor/phpunit/phpunit/src/TextUI/Application.php(103): PHPUnit\TextUI\Application->buildTestSuite()
#8 /home/runner/work/laravel-stock/laravel-stock/vendor/pestphp/pest/src/Kernel.php(91): PHPUnit\TextUI\Application->run()
#9 /home/runner/work/laravel-stock/laravel-stock/vendor/pestphp/pest/bin/pest(91): Pest\Kernel->handle()
#10 /home/runner/work/laravel-stock/laravel-stock/vendor/pestphp/pest/bin/pest(99): {closure}()
#11 /home/runner/work/laravel-stock/laravel-stock/vendor/bin/pest(119): include('...')
#12 {main}.
```