### PR TITLE
Update configure.php

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -174,7 +174,7 @@ function searchCommitsForGitHubUsername(): string
     $authorName = strtolower(trim(shell_exec('git config user.name')));
 
     $committersRaw = shell_exec("git log --author='@users.noreply.github.com' --pretty='%an:%ae' --reverse");
-    $committersLines = explode("\n", $committersRaw);
+    $committersLines = explode("\n", $committersRaw ?? '');
     $committers = array_filter(array_map(function ($line) use ($authorName) {
         $line = trim($line);
         [$name, $email] = explode(':', $line) + [null, null];


### PR DESCRIPTION
Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated in configure.php on line 177