### PR TITLE
Add return type declaration to function

### DIFF
--- a/src/Facades/Skeleton.php
+++ b/src/Facades/Skeleton.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Facade;
  */
 class Skeleton extends Facade
 {
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return \VendorName\Skeleton\Skeleton::class;
     }


### PR DESCRIPTION
Title: Add return type declaration to the getFacadeAccessor method of the Skeleton class

Description:
In this PR, I added a return type declaration to the `getFacadeAccessor` method. This change can improve our code quality because:

1. It makes the code clearer and easier to read. By explicitly specifying the return type in the method signature, other developers can more easily understand the expected behavior of this method.
2. It can help us avoid type errors at runtime. If we try to return the wrong type, PHP will throw an error at compile time, not at runtime.

I look forward to your feedback!