### PR TITLE
Workflows: Remove PHP 8.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.3, 8.2, 8.1]
+        php: [8.3, 8.2]
         laravel: [10.*]
         stability: [prefer-lowest, prefer-stable]
         include:


### PR DESCRIPTION
The `composer.json` file requires PHP 8.2 but the `run-tests` workflow was still including PHP 8.1.

This pull request removes it from the matrix so that tests don't fail.