### PR TITLE
fix: caret for installing carbon dependency on windows workflow now escaped correctly

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.os == 'windows-latest' && '^^^' || '' }}${{ matrix.carbon }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies


### PR DESCRIPTION
This solves an issue related to the note in this section of composer docs: 
https://getcomposer.org/doc/articles/versions.md#caret-version-range-

Compare the failed Windows job with the successful Ubuntu job here (a package created with this skeleton): https://github.com/patrick-cullen/env-title/actions/runs/9166402787/job/25201714149

Successful Ubuntu job output: 
```
Run composer require "laravel/framework:10.*" "orchestra/testbench:8.*" "nesbot/carbon:^2.63" --no-interaction --no-update
orchestra/testbench is currently present in the require-dev key and you ran the command without the --dev flag, which will move it to the require key.
./composer.json has been updated
```

Failed Windows job output (note the second line): 
```
Run composer require "laravel/framework:10.*" "orchestra/testbench:8.*" "nesbot/carbon:^2.63" --no-interaction --no-update
The "2.63" constraint for "nesbot/carbon" appears too strict and will likely not match what you want. See https://getcomposer.org/constraints
orchestra/testbench is currently present in the require-dev key and you ran the command without the --dev flag, which will move it to the require key.
./composer.json has been updated

```
