### PR TITLE
Remove depreciated option from phpstan.neon.dist

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,5 +10,3 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
-


### PR DESCRIPTION
### **Remove checkMissingIterableValueType option since it is depreceated**

_With `checkMissingIterableValueType: false` in the config, i get the following output:_

```shell
❯ vendor/bin/phpstan
Note: Using configuration file path/to/project/phpstan.neon.dist.
⚠️  You're using a deprecated config option checkMissingIterableValueType ⚠️️

It's strongly recommended to remove it from your configuration file
and add the missing array typehints.

If you want to continue ignoring missing typehints from arrays,
add missingType.iterableValue error identifier to your ignoreErrors:

parameters:
    ignoreErrors:
        - identifier: missingType.iterableValue

 6/6 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
``` 

_So, I replaced `checkMissingIterableValueType: false` with the following:_

```shell
ignoreErrors:
    - identifier: missingType.iterableValue
``` 

_But then, I get a new error:_

```shell
❯ vendor/bin/phpstan
Note: Using configuration file path/to/project/phpstan.neon.dist.
 6/6 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 -- ------------------------------------------------------------------------------------- 
     Error                                                                                
 -- ------------------------------------------------------------------------------------- 
     Ignored error pattern missingType.iterableValue was not matched in reported errors.  
 -- ------------------------------------------------------------------------------------- 
``` 

It seemed like that option was irrelevant for a new project created with this skeleton.

Also, from phpstan docs, missing typehints are checked from `Level: 6`, irrelevant for our config of `Level: 5`
https://phpstan.org/config-reference#vague-typehints

So, I thought it would be better to remove it from the skeleton as users can add it later if they want.