### PR TITLE
Use migration_table_name in service provider

### DIFF
--- a/src/SkeletonServiceProvider.php
+++ b/src/SkeletonServiceProvider.php
@@ -19,7 +19,7 @@ class SkeletonServiceProvider extends PackageServiceProvider
             ->name('skeleton')
             ->hasConfigFile()
             ->hasViews()
-            ->hasMigration('create_skeleton_table')
+            ->hasMigration('create_migration_table_name_table')
             ->hasCommand(SkeletonCommand::class);
     }
 }


### PR DESCRIPTION
Hi! This PR is intended to solve an issue with the service provider template which uses `skeleton` instead of `migration_table_name` placeholder in the argument of `hasMigration`. 