### PR TITLE
Fix issue template URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question
-    url: https://github.com/:vendor_name/:package_name/discussions/new?category=q-a
+    url: https://github.com/:vendor_slug/:package_name/discussions/new?category=q-a
     about: Ask the community for help
   - name: Request a feature
-    url: https://github.com/:vendor_name/:package_name/discussions/new?category=ideas
+    url: https://github.com/:vendor_slug/:package_name/discussions/new?category=ideas
     about: Share ideas for new features
   - name: Report a security issue
-    url: https://github.com/:vendor_name/:package_name/security/policy
+    url: https://github.com/:vendor_slug/:package_name/security/policy
     about: Learn how to notify us for sensitive bugs


### PR DESCRIPTION
The URLs for issue templates are using the vendor name, which appears to default to using the full name of the author, not a URL-friendly slug.