### PR TITLE
fix typo in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -50,7 +50,7 @@ body:
     - type: dropdown
       id: operating-systems
       attributes:
-        label: Which operating systems does with happen with?
+        label: Which operating systems does this happen with?
         description: You may select more than one.
         multiple: true
         options:


### PR DESCRIPTION
Spotted this typo in the laravel-pdf repo and thought it'd be best to fix it here rather than in a single repo.