### PR TITLE
Detect migrations automatically in `TestCase`

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,6 @@
 namespace VendorName\Skeleton\Tests;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Facades\File;
 use Orchestra\Testbench\TestCase as Orchestra;
 use VendorName\Skeleton\SkeletonServiceProvider;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace VendorName\Skeleton\Tests;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\File;
 use Orchestra\Testbench\TestCase as Orchestra;
 use VendorName\Skeleton\SkeletonServiceProvider;
 
@@ -27,10 +28,11 @@ class TestCase extends Orchestra
     public function getEnvironmentSetUp($app)
     {
         config()->set('database.default', 'testing');
-
-        /*
-        $migration = include __DIR__.'/../database/migrations/create_skeleton_table.php.stub';
-        $migration->up();
-        */
+		
+		/*
+		 foreach (\Illuminate\Support\Facades\File::allFiles(__DIR__ . '/database/migrations') as $migration) {
+		    (require $migration->getRealPath())->up();
+		 }
+		 */
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -30,7 +30,7 @@ class TestCase extends Orchestra
 		
 		/*
 		 foreach (\Illuminate\Support\Facades\File::allFiles(__DIR__ . '/database/migrations') as $migration) {
-		    (require $migration->getRealPath())->up();
+		    (include $migration->getRealPath())->up();
 		 }
 		 */
     }


### PR DESCRIPTION
Hello! Thank you for the nice package, I've used it a lot on (I think) all my packages!

Currently, in the `TestCase` file, people have to manually provide their migration paths. I've always found this a bit surprising/not-DX friendly, as it is very easy to just get and run all migrations instead of manually needing to provide the full path(s). Therefore, this PR replaces it with a simple snippet to just run all migrations in the `database/migrations` path.

The snippet is using the `File::allFiles()` method. This is fine, the only thing is that people would need to import the file after uncommenting for the most clean result. Alternatives like the `scandir()` function are also not great, as `scandir()` is returning results like `.` or `..` and then the snippet to un-comment would start to contain if-conditions, even less nice.

Thanks!