### PR TITLE
Fix PHP 8.3 and Laravel 10 compatibility

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,7 +30,7 @@ jobs:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 10.*
-            testbench: 8.*
+            testbench: ^8.22
     
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.4",
+        "php": "^8.3",
         "spatie/laravel-package-tools": "^1.16",
         "illuminate/contracts": "^10.0||^11.0||^12.0"
     },
@@ -25,9 +25,9 @@
         "nunomaduro/collision": "^8.1.1||^7.10.0",
         "larastan/larastan": "^2.9||^3.0",
         "orchestra/testbench": "^10.0.0||^9.0.0||^8.22.0",
-        "pestphp/pest": "^3.0",
-        "pestphp/pest-plugin-arch": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.0",
+        "pestphp/pest": "^2.0||^3.0",
+        "pestphp/pest-plugin-arch": "^2.5||^3.0",
+        "pestphp/pest-plugin-laravel": "^2.0||^3.0",
         "phpstan/extension-installer": "^1.3||^2.0",
         "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
         "phpstan/phpstan-phpunit": "^1.3||^2.0",


### PR DESCRIPTION
## Description

This PR fixes compatibility issues between composer.json requirements and the GitHub Actions workflow, enabling support for PHP 8.3+ and Laravel 10+.

## Problem

The current template has several compatibility issues:
- composer.json requires PHP ^8.4, but the workflow tests against PHP 8.3
- Laravel 10 requires Pest v2, but composer.json only allows Pest v3
- The workflow uses a wildcard version for testbench (8.*) which can install incompatible versions during prefer-lowest installations

## Solution

### composer.json changes:
- Lower PHP requirement from `^8.4` to `^8.3` to match the workflow matrix
- Add support for Pest v2 alongside v3 (`^2.0||^3.0`) for Laravel 10 compatibility
- Update pest plugin constraints to support both v2 and v3 versions

### Workflow changes:
- Change testbench from wildcard (`8.*`) to caret (`^8.22`) to ensure compatible versions

## Testing

I've created a test package that demonstrates these changes work correctly: https://github.com/christopheraseidl/test-skeleton-patch

This test package shows:
- Successful installation with PHP 8.3 and Laravel 10
- All tests passing with the updated dependencies
- No conflicts during prefer-lowest installations