### PR TITLE
Remove invalid PHPStan Extension Installer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "pestphp/pest": "^2.0||^3.0",
         "pestphp/pest-plugin-arch": "^2.5||^3.0",
         "pestphp/pest-plugin-laravel": "^2.0||^3.0",
-        "phpstan/extension-installer": "^1.3||^2.0",
+        "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
         "phpstan/phpstan-phpunit": "^1.3||^2.0",
         "spatie/laravel-ray": "^1.35"


### PR DESCRIPTION
Version 2.0 or above does not exist.