### PR TITLE
Fix `phpstan/extension-installer` dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-arch": "^4.0",
         "pestphp/pest-plugin-laravel": "^4.0",
-        "phpstan/extension-installer": "^2.0",
+        "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "spatie/laravel-ray": "^1.35"


### PR DESCRIPTION
The recently changed version (`^2.0`) for `phpstan/extension-installer` doesn't exist on [GitHub](https://github.com/phpstan/extension-installer) or [Packagist](https://packagist.org/packages/phpstan/extension-installer).

I've reverted it back to `^1.4`.

Occured to me while trying to upgrade the deps in [my package](https://github.com/ace-of-aces/laravel-image-transform-url) which is using this template :)

<img width="1432" height="175" alt="Screenshot 2025-08-25 at 22 25 00" src="https://github.com/user-attachments/assets/985d5bb1-2b44-42f1-ad8d-beb91b80df5d" />
