### PR TITLE
fix: illuminate/contracts dependency version to support Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.4",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^11.0||^12.0"
+        "illuminate/contracts": "^11.0||^12.0||^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",


### PR DESCRIPTION
This PR updates the package skeleton so newly generated packages support Laravel 13 out of the box.