### PR TITLE
Update orchestra/testbench version constraints to allow version 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.8",
         "larastan/larastan": "^3.0",
-        "orchestra/testbench": "^10.0.0||^9.0.0",
+        "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-arch": "^4.0",
         "pestphp/pest-plugin-laravel": "^4.0",


### PR DESCRIPTION
Allow version 11 of orchestra/testbench