### PR TITLE
Set default package cooldowns for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
 
 version: 2
 updates:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 1
 
   - package-ecosystem: "composer"
     directory: "/"
@@ -17,3 +19,5 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 1


### PR DESCRIPTION
Given the recent surge of supply chain attacks, I think adding a small delay to package updates through dependabot could minimize this risk a little (even tho this issue is not as bad in the composer ecosystem as in npm).

Added default package [`cooldown` settings](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) for github-actions and composer dependencies, set to 1 day (following the [default in pnpm](https://pnpm.io/supply-chain-security#delay-dependency-updates)).